### PR TITLE
Refatorando

### DIFF
--- a/__tests__/integration/manifestation.test.js
+++ b/__tests__/integration/manifestation.test.js
@@ -130,25 +130,27 @@ describe('Manifestation', () => {
         categories_id: [category.id],
       });
 
+    // pegar o protocolo
+    const {
+      body: { protocol },
+    } = await request(app)
+      .get(`/manifestation/${createdManifestation.id}`)
+      .set('Authorization', `Bearer ${token}`)
+      .send();
+
     // listar
     const response = await request(app)
-      .get('/manifestation')
-      .query({ text: createdManifestation.protocol })
+      .get(`/manifestation/${protocol}`)
       .set('Authorization', `Bearer ${token}`)
       .send();
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual(
-      expect.objectContaining({ count: 1, last_page: 1 })
-    );
-    expect(response.body.rows).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          title: 'title',
-          description: 'description',
-          protocol: createdManifestation.protocol,
-        }),
-      ])
+      expect.objectContaining({
+        title: 'title',
+        description: 'description',
+        protocol,
+      })
     );
   });
 

--- a/__tests__/integration/user.test.js
+++ b/__tests__/integration/user.test.js
@@ -104,10 +104,17 @@ describe('User', () => {
   });
 
   it('should list all users', async () => {
+    const user = { email: 'root@gmail.com', password: '123456' };
+
+    // login
+    const { body } = await sign.in(user);
+
     const response = await request(app)
       .get('/user')
+      .set('Authorization', `Bearer ${body.token}`)
       .send();
 
+    expect(response.status).toBe(200);
     expect(response.body[0]).toHaveProperty(
       'email',
       'first_name',
@@ -119,11 +126,13 @@ describe('User', () => {
     expect(response.body[0].role[0]).toHaveProperty('level', 'id', 'title');
   });
 
-  it('should list a specific users', async () => {
-    const { body } = await sign.up(await factory.attrs('User'));
+  it('should list a specific user', async () => {
+    const user = { email: 'root@gmail.com', password: '123456' };
+    const { body } = await sign.in(user); // login
 
     const response = await request(app)
-      .get(`/user/${body.id}`)
+      .get(`/user/${body.user.id}`)
+      .set('Authorization', `Bearer ${body.token}`)
       .send();
 
     expect(response.body).toHaveProperty(
@@ -133,13 +142,20 @@ describe('User', () => {
       'last_name',
       'role'
     );
-
     expect(response.body.role[0]).toHaveProperty('level', 'id', 'title');
   });
 
   it("shouldn't list a specific user", async () => {
+    const user = { email: 'root@gmail.com', password: '123456' };
+
+    // cadastro
+    await sign.up(user);
+    // login
+    const { body } = await sign.in(user);
+
     const response = await request(app)
       .get(`/user/0`)
+      .set('Authorization', `Bearer ${body.token}`)
       .send();
 
     expect(response.body).toHaveProperty('error', 'esse usuário não existe');

--- a/__tests__/unit/searchManifestationService.test.js
+++ b/__tests__/unit/searchManifestationService.test.js
@@ -6,21 +6,24 @@ import Category from '../../src/app/models/Category';
 import searchManifestationService from '../../src/app/services/SearchManifestationService';
 import User from '../../src/app/models/User';
 
+let type;
+let category;
+
 describe('Search Manifestation Service', () => {
   // entre todos os testes é feito o truncate da tabela
   beforeEach(async () => {
     await truncate();
-  });
 
-  it('should search for manifestations', async () => {
-    const type = await Type.create({ title: 'Reclamação' });
+    type = await Type.create({ title: 'Reclamação' });
     expect(type).toBeDefined();
     expect(type).toHaveProperty('id');
 
-    const category = await Category.create({ title: 'Saneamento' });
+    category = await Category.create({ title: 'Saneamento' });
     expect(category).toBeDefined();
     expect(category).toHaveProperty('id');
+  });
 
+  it('should search for manifestations', async () => {
     const user = await User.create({
       email: 'email@gmail.com',
       first_name: 'Nome',
@@ -42,6 +45,7 @@ describe('Search Manifestation Service', () => {
     }
 
     const manifestations = await searchManifestationService.run('rua');
+
     expect(manifestations).toHaveProperty('count');
     expect(manifestations).toHaveProperty('last_page');
     expect(manifestations).toHaveProperty('rows');

--- a/routes.md
+++ b/routes.md
@@ -568,7 +568,7 @@ _retorna_:
 
 ### manifestation status history
 
-- **GET** `manifestation/:manifestationId/status`: retorna todos os status de uma manifestação.
+- **GET** `manifestation/:idOrProtocol/status`: retorna todos os status de uma manifestação.
 
 ```json
 [

--- a/routes.md
+++ b/routes.md
@@ -28,7 +28,7 @@ Contêm protocolo _HTTP_, endereço da rota, explicação do que é feito, o que
 ]
 ```
 
-- **GET** `user/:id?`: essa mesma rota pode receber o id de um _users_ específico, retornando assim o usuário.
+- **GET** `user/:id`: retorna o usuário que tem esse id.
 
 ```json
 {
@@ -45,9 +45,9 @@ Contêm protocolo _HTTP_, endereço da rota, explicação do que é feito, o que
 }
 ```
 
-- **POST** `user/create`: cria um novo registro na tabela de _users_.
+- **POST** `user/`: cria um novo registro na tabela de _users_.
 
-Existem dois tipos de requisições possiveis aqui, uma incluí o atributo 'role' mas é necessário um token de usuário de nivel master no header na requisição, e a outra é sem o atributo role.
+Existem **dois** tipos de requisições possiveis aqui, uma incluí o atributo 'role' mas é **necessário um token** de usuário de nivel master no header na requisição, e a outra é sem o atributo role.
 
 _requisição sem role_:
 
@@ -168,7 +168,7 @@ _retorna_:
 }
 ```
 
-- **GET** `manifestation/:id?`: essa mesma rota pode receber o id de uma manifestação específica, retornando assim a manifestação.
+- **GET** `manifestation/:id`: retorna a manifestação que tem esse id.
 
 _retorna_:
 
@@ -272,7 +272,7 @@ _retorna_:
 ]
 ```
 
-- **GET** `category/:id?`: essa mesma rota pode receber o id de um _categories_ específico, retornando assim a categoria.
+- **GET** `category/:id`: retorna a categoria que tem esse id.
 
 ```json
 {
@@ -356,7 +356,7 @@ _retorna_:
 ]
 ```
 
-- **GET** `role/:id?`: essa mesma rota pode receber o id de um _role_ específico, retornando assim o role.
+- **GET** `role/:id`: retorna a Role que tem esse id.
 
 ```json
 {
@@ -433,7 +433,7 @@ _retorna_:
 ]
 ```
 
-- **GET** `type/:id?`: essa mesma rota pode receber o id de um _type_ específico, retornando assim o status.
+- **GET** `type/:id`: retorna o Type que tem esse id.
 
 ```json
 {
@@ -506,7 +506,7 @@ _retorna_:
 ]
 ```
 
-- **GET** `status/:id?`: essa mesma rota pode receber o id de um _status_ específico, retornando assim o status.
+- **GET** `status/:id`: retorna o Status que tem esse id.
 
 ```json
 {
@@ -566,6 +566,101 @@ _retorna_:
 }
 ```
 
+### manifestation status history
+
+- **GET** `manifestation/:manifestationId/status`: retorna todos os status de uma manifestação.
+
+```json
+[
+  {
+    "id": 1,
+    "description": "descrição, motivo para a mudança do status",
+    "created_at": "2019-12-16T17:24:58.000Z",
+    "updated_at": "2019-12-16T17:24:58.000Z",
+    "status_id": 1,
+    "manifestation_id": 4,
+    "secretary_id": 1
+  }
+]
+```
+
+- **GET** `manifestation/status/:id`: retorna um status específico de uma manifestação.
+
+```json
+{
+  "id": 1,
+  "description": "descrição, motivo para a mudança do status",
+  "created_at": "2019-12-16T17:24:58.000Z",
+  "updated_at": "2019-12-16T17:24:58.000Z",
+  "status_id": 1,
+  "manifestation_id": 4,
+  "secretary_id": 1
+}
+```
+
+- **POST** `/manifestation/:manifestationId/status`: cria um novo status para a manifestação.
+
+_requisição_:
+
+```json
+{
+  "description": "descrição, motivo para a mudança do status",
+  "status_id": 1,
+  "secretary_id": 1
+}
+```
+
+_retorna_:
+
+```json
+{
+  "id": 1,
+  "description": "descrição, motivo para a mudança do status",
+  "manifestation_id": "4",
+  "status_id": 1,
+  "secretary_id": 1,
+  "updated_at": "2019-12-16T17:24:58.115Z",
+  "created_at": "2019-12-16T17:24:58.115Z"
+}
+```
+
+- **PUT** `manifestation/status/:id`: atualiza um status específico de uma manifestação.
+
+_requisição_:
+
+```json
+{
+  "description": "descrição atualizada"
+}
+```
+
+_retorna_:
+
+```json
+{
+  "id": 1,
+  "description": "descrição atualizada",
+  "created_at": "2019-12-16T17:24:58.000Z",
+  "updated_at": "2019-12-16T17:40:57.859Z",
+  "status_id": 1,
+  "manifestation_id": 4,
+  "secretary_id": 1
+}
+```
+
+- **DELETE** `status/:id`: deleta um registro de acordo com o id passado no parametro da rota na tabela de _status_.
+
+_retorna_:
+
+```json
+{
+  "id": 1,
+  "title": "Em andamento",
+  "created_at": "2019-10-31T17:01:37.000Z",
+  "updated_at": "2019-10-31T17:01:37.000Z"
+}
+```
+
 ### secretary
 
 - **GET** `secretary/`: retorna todos os registros na tabela de _secretariats_.
@@ -580,7 +675,7 @@ _retorna_:
 ]
 ```
 
-- **GET** `secretary/:id?`: essa mesma rota pode receber o id de um _secretariats_ específico, retornando assim a secretaria.
+- **GET** `secretary/:id`: retorna a secretaria que tem esse id.
 
 ```json
 {

--- a/src/app/controller/category.controller.js
+++ b/src/app/controller/category.controller.js
@@ -1,22 +1,24 @@
 import Category from '../models/Category';
 
 class CategoryController {
+  // retorna todas as categorias
   async fetch(req, res) {
-    if (req.params.id) {
-      const type = await Category.findByPk(req.params.id, {
-        attributes: ['id', 'title'],
-      });
-
-      if (!type) {
-        return res.status(400).json({ error: 'essa categoria não existe' });
-      }
-
-      return res.status(200).json(type);
-    }
-
     const categories = await Category.findAll({ attributes: ['id', 'title'] });
 
     return res.status(200).json(categories);
+  }
+
+  // retorna apenas uma Categoria
+  async show(req, res) {
+    const type = await Category.findByPk(req.params.id, {
+      attributes: ['id', 'title'],
+    });
+
+    if (!type) {
+      return res.status(400).json({ error: 'essa categoria não existe' });
+    }
+
+    return res.status(200).json(type);
   }
 
   // salva a category no banco

--- a/src/app/controller/mail.controller.js
+++ b/src/app/controller/mail.controller.js
@@ -2,7 +2,7 @@ import Mail from '../../lib/Mail';
 
 class MailController {
   // envia um email
-  async save(req, res) {
+  async send(req, res) {
     const { title, text, email } = req.body;
 
     try {

--- a/src/app/controller/manifestation.controller.js
+++ b/src/app/controller/manifestation.controller.js
@@ -113,7 +113,6 @@ class ManifestationController {
         ...formattedData,
         user_id: req.user_id,
       });
-      console.log(manifestation);
     } catch (error) {
       // é possivel que ocorra um erro se o token estiver invalido
       console.error(error);
@@ -131,6 +130,8 @@ class ManifestationController {
       return res.status(500).json({ error: 'Erro interno no servidor' });
     }
 
+    // o protocolo não foi gerado ainda, portanto ele fica 0
+    delete manifestation.dataValues.protocol;
     return res.status(200).json(manifestation);
   }
 

--- a/src/app/controller/manifestation.controller.js
+++ b/src/app/controller/manifestation.controller.js
@@ -7,7 +7,7 @@ import GeolocationService from '../services/GeolocationService';
 class ManifestationController {
   async fetch(req, res) {
     /**
-     * text: titulo da manifestação
+     * text: titulo da manifestação ou protocolo
      * options: array de categorias e tipos de manifestações
      * isRead: flag para pesquisar apenas por manifestações lidas, 0 ou 1
      * page: a página para ser pesquisada, o resultado é limitado em 10 itens

--- a/src/app/controller/manifestation.controller.js
+++ b/src/app/controller/manifestation.controller.js
@@ -5,6 +5,100 @@ import SearchManifestationService from '../services/SearchManifestationService';
 import GeolocationService from '../services/GeolocationService';
 
 class ManifestationController {
+  async fetch(req, res) {
+    /**
+     * text: titulo da manifestação
+     * options: array de categorias e tipos de manifestações
+     * isRead: flag para pesquisar apenas por manifestações lidas, 0 ou 1
+     * page: a página para ser pesquisada, o resultado é limitado em 10 itens
+     */
+    const { text, options } = req.query;
+    let { page = 1, isRead = 1 } = req.query;
+    page = Number(page);
+    isRead = Number(isRead);
+
+    let manifestations;
+
+    // pesquisa com filtro
+    if (text || options) {
+      manifestations = await SearchManifestationService.run(
+        text,
+        options,
+        page,
+        isRead
+      );
+    } else {
+      // pesquisa por todas as manifestações
+      manifestations = await Manifestation.findAndCountAll({
+        include: [
+          {
+            model: Category,
+            as: 'categories',
+            // só pega o id e o título
+            attributes: ['id', 'title'],
+            // a linha abaixo previne que venham informações desnecessárias
+            through: { attributes: [] },
+          },
+          {
+            model: Type,
+            as: 'type',
+            attributes: ['id', 'title'],
+          },
+        ],
+        // caso receba isRead, pesquisa apenas por manifestações lidas
+        ...(!isRead && { where: { read: 0 } }),
+        limit: 10,
+        offset: 10 * page - 10,
+      });
+    }
+
+    // retorna qual a ultima página
+    manifestations.last_page = Math.ceil(manifestations.count / 10);
+
+    // gambiarra, ele ta contando um a mais
+    // manifestations.count -= 1;
+
+    return res.status(200).json(manifestations);
+  }
+
+  async show(req, res) {
+    const { idOrProtocol } = req.params;
+    let isProtocol = false;
+
+    // checa se é um protocolo
+    if (idOrProtocol && idOrProtocol.match(/\d*-\d/)) {
+      isProtocol = true;
+    }
+
+    const manifestation = await Manifestation.findOne({
+      where: {
+        // decide se busca por protocolo ou id
+        ...(isProtocol ? { protocol: idOrProtocol } : { id: idOrProtocol }),
+      },
+      include: [
+        {
+          model: Category,
+          as: 'categories',
+          // só pega o id e o título
+          attributes: ['id', 'title'],
+          // a linha abaixo previne que venham informações desnecessárias
+          through: { attributes: [] },
+        },
+        {
+          model: Type,
+          as: 'type',
+          attributes: ['id', 'title'],
+        },
+      ],
+    });
+
+    if (!manifestation) {
+      return res.status(400).json({ error: 'essa manifestação não existe' });
+    }
+
+    return res.status(200).json(manifestation);
+  }
+
   async save(req, res) {
     // Cria a manifestação e salva no banco
     const { categories_id, ...data } = req.body;
@@ -19,6 +113,7 @@ class ManifestationController {
         ...formattedData,
         user_id: req.user_id,
       });
+      console.log(manifestation);
     } catch (error) {
       // é possivel que ocorra um erro se o token estiver invalido
       console.error(error);
@@ -37,77 +132,6 @@ class ManifestationController {
     }
 
     return res.status(200).json(manifestation);
-  }
-
-  async fetch(req, res) {
-    /**
-     * text: titulo da manifestação
-     * options: array de categorias e tipos de manifestações
-     * isRead: flag para pesquisar apenas por manifestações lidas, 0 ou 1
-     * page: a página para ser pesquisada, o resultado é limitado em 10 itens
-     */
-    const { text, options } = req.query;
-    let { page = 1, isRead = 1 } = req.query;
-    page = Number(page);
-    isRead = Number(isRead);
-
-    const query = {
-      include: [
-        {
-          model: Category,
-          as: 'categories',
-          // só pega o id e o título
-          attributes: ['id', 'title'],
-          // a linha abaixo previne que venham informações desnecessárias
-          through: { attributes: [] },
-        },
-        {
-          model: Type,
-          as: 'type',
-          attributes: ['id', 'title'],
-        },
-      ],
-    };
-
-    // pesquisa por manifestação especifica
-    if (req.params.id) {
-      const manifestation = await Manifestation.findByPk(req.params.id, query);
-
-      if (!manifestation) {
-        return res.status(400).json({ error: 'essa manifestação não existe' });
-      }
-
-      return res.status(200).json(manifestation);
-    }
-
-    // pesquisa com filtro
-    if (text || options) {
-      const manifestations = await SearchManifestationService.run(
-        text,
-        options,
-        page,
-        isRead
-      );
-
-      return res.status(200).json(manifestations);
-    }
-
-    // pesquisa por todas as manifestações
-    const manifestations = await Manifestation.findAndCountAll({
-      ...query,
-      // caso receba isRead, pesquisa apenas por manifestações lidas
-      ...(!isRead && { where: { read: 0 } }),
-      limit: 10,
-      offset: 10 * page - 10,
-    });
-
-    // gambiarra, ele ta contando um a mais
-    // manifestations.count -= 1;
-
-    // retorna qual a ultima página
-    manifestations.last_page = Math.ceil(manifestations.count / 10);
-
-    return res.status(200).json(manifestations);
   }
 
   async update(req, res) {

--- a/src/app/controller/manifestationStatusHistory.controller.js
+++ b/src/app/controller/manifestationStatusHistory.controller.js
@@ -1,4 +1,5 @@
 import Manifestation from '../models/Manifestation';
+import Status from '../models/Status';
 import ManifestationStatusHistory from '../models/ManifestationStatusHistory';
 
 class ManifestationStatusHistoryController {
@@ -43,6 +44,7 @@ class ManifestationStatusHistoryController {
         // procura por manifestação com esse protocolo
         const manifestation = await Manifestation.findOne({
           where: { protocol: idOrProtocol },
+          attributes: ['id'],
         });
 
         // agora que tem o protocolo busca pelo id
@@ -52,6 +54,13 @@ class ManifestationStatusHistoryController {
       } else {
         manifestationStatusHistory = await ManifestationStatusHistory.findAll({
           where: { manifestation_id: idOrProtocol },
+          include: [
+            {
+              model: Status,
+              as: 'status',
+              attributes: ['title'],
+            },
+          ],
         });
       }
 

--- a/src/app/controller/manifestationStatusHistory.controller.js
+++ b/src/app/controller/manifestationStatusHistory.controller.js
@@ -29,20 +29,31 @@ class ManifestationStatusHistoryController {
   }
 
   async fetch(req, res) {
-    const { manifestationId } = req.params;
+    const { idOrProtocol } = req.params;
+    let isProtocol = false;
+    let manifestationStatusHistory;
 
-    // checar se a manifestação existe
-    const manifestation = await Manifestation.findByPk(manifestationId, {
-      attributes: ['id'],
-    });
-    if (!manifestation) {
-      return res.status(400).json({ errro: 'Essa manifestação não existe' });
+    // checa se é um protocolo
+    if (idOrProtocol && idOrProtocol.match(/\d*-\d/)) {
+      isProtocol = true;
     }
 
     try {
-      const manifestationStatusHistory = await ManifestationStatusHistory.findAll(
-        { where: { manifestation_id: manifestation.id } }
-      );
+      if (isProtocol) {
+        // procura por manifestação com esse protocolo
+        const manifestation = await Manifestation.findOne({
+          where: { protocol: idOrProtocol },
+        });
+
+        // agora que tem o protocolo busca pelo id
+        manifestationStatusHistory = await ManifestationStatusHistory.findAll({
+          where: { manifestation_id: manifestation.id },
+        });
+      } else {
+        manifestationStatusHistory = await ManifestationStatusHistory.findAll({
+          where: { manifestation_id: idOrProtocol },
+        });
+      }
 
       return res.status(200).json(manifestationStatusHistory);
     } catch (error) {

--- a/src/app/controller/manifestationStatusHistory.controller.js
+++ b/src/app/controller/manifestationStatusHistory.controller.js
@@ -1,0 +1,91 @@
+import Manifestation from '../models/Manifestation';
+import ManifestationStatusHistory from '../models/ManifestationStatusHistory';
+
+class ManifestationStatusHistoryController {
+  async fetchManifestation(id) {
+    const manifestation = await Manifestation.findByPk(id);
+
+    if (!manifestation) throw new Error('Essa manifestação não existe');
+
+    return manifestation;
+  }
+
+  async save(req, res) {
+    const { description, status_id, secretary_id } = req.body;
+    const { manifestationId } = req.params;
+
+    try {
+      await this.fetchManifestation(req.params.manifestationId);
+    } catch (error) {
+      return res.status(400).json({ error });
+    }
+
+    try {
+      const manifestationStatus = await ManifestationStatusHistory.create({
+        description,
+        manifestation_id: manifestationId,
+        status_id,
+        secretary_id,
+      });
+
+      return res.status(200).json(manifestationStatus);
+    } catch (error) {
+      return res.status(500).json({ error: 'Erro interno no servidor' });
+    }
+  }
+
+  async fetch(req, res) {
+    const { manifestationId, id } = req.params;
+
+    // checar se a manifestação existe
+    try {
+      await this.fetchManifestation(manifestationId);
+    } catch (error) {
+      return res.status(400).json({ error });
+    }
+
+    try {
+      // caso esteja buscando um status de manifestação específico
+      if (id) {
+        const manifestationStatus = await ManifestationStatusHistory.findByPk(
+          id
+        );
+
+        return res.status(200).json(manifestationStatus);
+      }
+
+      // caso normal, onde não é especificado o id
+      const manifestationStatusHistory = await ManifestationStatusHistory.findAll(
+        { where: { manifestation_id: manifestationId } }
+      );
+
+      return res.status(200).json(manifestationStatusHistory);
+    } catch (error) {
+      return res.status(500).json({ error: 'Erro interno no servidor' });
+    }
+  }
+
+  async update(req, res) {
+    const { manifestationId, id } = req.params;
+
+    try {
+      await this.fetchManifestation(manifestationId);
+    } catch (error) {
+      return res.status(400).json({ error });
+    }
+
+    try {
+      const manifestationStatus = await ManifestationStatusHistory.findByPk(id);
+
+      const updatedManifestationStatus = await manifestationStatus.update(
+        req.body
+      );
+
+      return res.status(200).json(updatedManifestationStatus);
+    } catch (error) {
+      return res.status(500).json({ error: 'Erro interno no servidor' });
+    }
+  }
+} // fim da classe
+
+export default new ManifestationStatusHistoryController();

--- a/src/app/controller/role.controller.js
+++ b/src/app/controller/role.controller.js
@@ -3,21 +3,19 @@ import Role from '../models/Role';
 class RoleController {
   // Retorna todas entries de Roles no DB
   async fetch(req, res) {
-    const queryConfig = {
+    const role = await Role.findAll({ attributes: ['id', 'title', 'level'] });
+
+    return res.status(200).json(role);
+  }
+
+  async show(req, res) {
+    const role = await Role.findByPk(req.params.id, {
       attributes: ['id', 'title', 'level'],
-    };
+    });
 
-    if (req.params.id) {
-      const role = await Role.findByPk(req.params.id, queryConfig);
-
-      if (!role) {
-        return res.status(400).json({ error: 'essa Role não existe' });
-      }
-
-      return res.status(200).json(role);
+    if (!role) {
+      return res.status(400).json({ error: 'essa Role não existe' });
     }
-
-    const role = await Role.findAll(queryConfig);
 
     return res.status(200).json(role);
   }

--- a/src/app/controller/secretary.controller.js
+++ b/src/app/controller/secretary.controller.js
@@ -3,19 +3,22 @@ import Secretary from '../models/Secretary';
 class SecretaryController {
   // retorna todos os Secretary registrados
   async fetch(req, res) {
-    const query = { attributes: ['id', 'title', 'email'] };
+    const secretary = await Secretary.findAll({
+      attributes: ['id', 'title', 'email'],
+    });
 
-    if (req.params.id) {
-      const secretary = await Secretary.findByPk(req.params.id, query);
+    return res.status(200).json(secretary);
+  }
 
-      if (!secretary) {
-        return res.status(400).json({ error: 'essa secretaria não existe' });
-      }
+  // retorna apenas uma Secretary
+  async show(req, res) {
+    const secretary = await Secretary.findByPk(req.params.id, {
+      attributes: ['id', 'title', 'email'],
+    });
 
-      return res.status(200).json(secretary);
+    if (!secretary) {
+      return res.status(400).json({ error: 'essa secretaria não existe' });
     }
-
-    const secretary = await Secretary.findAll(query);
 
     return res.status(200).json(secretary);
   }

--- a/src/app/controller/status.controller.js
+++ b/src/app/controller/status.controller.js
@@ -1,21 +1,22 @@
 import Status from '../models/Status';
 
 class StatusController {
-  // retorna todos os Status registrados
+  // retorna todos os Status
   async fetch(req, res) {
-    if (req.params.id) {
-      const status = await Status.findByPk(req.params.id, {
-        attributes: ['id', 'title'],
-      });
-
-      if (!status) {
-        return res.status(400).json({ error: 'esse status não existe' });
-      }
-
-      return res.status(200).json(status);
-    }
-
     const status = await Status.findAll({ attributes: ['id', 'title'] });
+
+    return res.status(200).json(status);
+  }
+
+  // retorna apenas um Status
+  async show(req, res) {
+    const status = await Status.findByPk(req.params.id, {
+      attributes: ['id', 'title'],
+    });
+
+    if (!status) {
+      return res.status(400).json({ error: 'esse status não existe' });
+    }
 
     return res.status(200).json(status);
   }

--- a/src/app/controller/type.controller.js
+++ b/src/app/controller/type.controller.js
@@ -1,21 +1,22 @@
 import Type from '../models/Type';
 
 class TypeController {
-  // retorna todos os Type registrados
+  // retorna todos os Type
   async fetch(req, res) {
-    if (req.params.id) {
-      const type = await Type.findByPk(req.params.id, {
-        attributes: ['id', 'title'],
-      });
-
-      if (!type) {
-        return res.status(400).json({ error: 'esse tipo não existe' });
-      }
-
-      return res.status(200).json(type);
-    }
-
     const type = await Type.findAll({ attributes: ['id', 'title'] });
+
+    return res.status(200).json(type);
+  }
+
+  // retorna apenas um Type
+  async show(req, res) {
+    const type = await Type.findByPk(req.params.id, {
+      attributes: ['id', 'title'],
+    });
+
+    if (!type) {
+      return res.status(400).json({ error: 'esse tipo não existe' });
+    }
 
     return res.status(200).json(type);
   }

--- a/src/app/controller/user.controller.js
+++ b/src/app/controller/user.controller.js
@@ -41,7 +41,7 @@ async function checkAdmin(header) {
 class UserController {
   // Retorna todas entries de Users no DB, temporário, !somente para teste!
   async fetch(req, res) {
-    const queryConfig = {
+    const users = await User.findAll({
       attributes: ['id', 'first_name', 'last_name', 'email'],
       include: [
         {
@@ -51,18 +51,28 @@ class UserController {
           through: { attributes: [] },
         },
       ],
-    };
-    if (req.params.id) {
-      const user = await User.findByPk(req.params.id, queryConfig);
-      if (!user) {
-        return res.status(400).json({ error: 'esse usuário não existe' });
-      }
-      return res.status(200).json(user);
-    }
-
-    const users = await User.findAll(queryConfig);
+    });
 
     return res.status(200).json(users);
+  }
+
+  async show(req, res) {
+    const user = await User.findByPk(req.params.id, {
+      attributes: ['id', 'first_name', 'last_name', 'email'],
+      include: [
+        {
+          model: Role,
+          as: 'role',
+          attributes: ['id', 'title', 'level'],
+          through: { attributes: [] },
+        },
+      ],
+    });
+
+    if (!user) {
+      return res.status(400).json({ error: 'esse usuário não existe' });
+    }
+    return res.status(200).json(user);
   }
 
   // salva o usuário no banco

--- a/src/app/middlewares/validators/ManifestationStatusHistory.js
+++ b/src/app/middlewares/validators/ManifestationStatusHistory.js
@@ -1,0 +1,69 @@
+/**
+ * Middleware de validação para Manifestation
+ * Docs do yup:
+ * https://github.com/jquense/yup
+ */
+import { object, string, number } from 'yup';
+
+class ManifestationStatusHistoryValidator {
+  async save(request, response, next) {
+    try {
+      // validar JSON
+      let schema = object().shape({
+        description: string().required('Descrição é necessária'),
+        status_id: number()
+          .min(1)
+          .required('Status é necessário'),
+        secretary_id: number().min(1),
+      });
+      await schema.validate(request.body, { abortEarly: false });
+
+      // validar PARAMS
+      schema = object().shape({
+        manifestationId: number()
+          .min(1)
+          .required('Id da manifestação deve ser passado'),
+      });
+      await schema.validate(request.params, { abortEarly: false });
+
+      return next();
+    } catch (error) {
+      return response.status(400).json({
+        error: 'Validação falhou',
+        // pega apenas a mensagens do erros
+        messages: error.inner.map(err => err.message),
+      });
+    }
+  }
+
+  async update(request, response, next) {
+    try {
+      // validar JSON
+      let schema = object().shape({
+        description: string(),
+        status_id: number().min(1),
+        secretary_id: number().min(1),
+      });
+      await schema.validate(request.body, { abortEarly: false });
+
+      // validar PARAMS
+      schema = object().shape({
+        manifestationId: number()
+          .min(1)
+          .required('Id da manifestação deve ser passado'),
+        id: number().required('Id do status da manifestação é necessário'),
+      });
+      await schema.validate(request.params, { abortEarly: false });
+
+      return next();
+    } catch (error) {
+      return response.status(400).json({
+        error: 'Validação falhou',
+        // pega apenas a mensagens do erros
+        messages: error.inner.map(err => err.message),
+      });
+    }
+  }
+}
+
+export default new ManifestationStatusHistoryValidator();

--- a/src/app/middlewares/validators/ManifestationStatusHistory.js
+++ b/src/app/middlewares/validators/ManifestationStatusHistory.js
@@ -48,9 +48,6 @@ class ManifestationStatusHistoryValidator {
 
       // validar PARAMS
       schema = object().shape({
-        manifestationId: number()
-          .min(1)
-          .required('Id da manifestação deve ser passado'),
         id: number().required('Id do status da manifestação é necessário'),
       });
       await schema.validate(request.params, { abortEarly: false });

--- a/src/app/models/Manifestation.js
+++ b/src/app/models/Manifestation.js
@@ -27,9 +27,9 @@ class Manifestation extends Model {
     // criação do protocolo. exemplo: 2019125-52
     this.addHook('afterCreate', async manifestation => {
       const date = new Date();
-      const year = date.getFullYear();
+      const year = date.getFullYear() % 100; // ultimos dois digitos
       const month = date.getMonth() + 1;
-      const day = date.getDay();
+      const day = date.getDate();
       const number = manifestation.id % 10000; // ultimos 4 números
       const protocol = `${year}${month}${day}-${number}`;
 

--- a/src/app/models/ManifestationStatusHistory.js
+++ b/src/app/models/ManifestationStatusHistory.js
@@ -1,13 +1,13 @@
+/**
+ * Model para a tabela manifestation_status_history
+ * Responsável por guardar o historico de status das manifestações
+ */
 import Sequelize, { Model } from 'sequelize';
 
 class ManifestationStatusHistory extends Model {
   static init(sequelize) {
     super.init(
       {
-        title: {
-          type: Sequelize.STRING,
-          unique: true,
-        },
         description: {
           type: Sequelize.TEXT,
           unique: true,
@@ -27,12 +27,23 @@ class ManifestationStatusHistory extends Model {
     return this;
   }
 
-  // static associate(models) {
-  //   this.hasMany(models.Status);
-  //   this.hasOne(models.Manifestation, {
-  //     foreignKey: 'manifestation_id',
-  //   });
-  // }
+  static associate(models) {
+    this.belongsTo(models.Status, {
+      foreignKey: 'status_id',
+      as: 'status',
+      targetKey: 'id',
+    });
+    this.belongsTo(models.Manifestation, {
+      foreignKey: 'manifestation_id',
+      as: 'manifestation',
+      targetKey: 'id',
+    });
+    this.belongsTo(models.Secretary, {
+      foreignKey: 'secretary_id',
+      as: 'secretary',
+      targetKey: 'id',
+    });
+  }
 }
 
 export default ManifestationStatusHistory;

--- a/src/app/services/SearchManifestationService.js
+++ b/src/app/services/SearchManifestationService.js
@@ -107,9 +107,10 @@ class SearchManifestationService {
       isRead
     );
 
-    console.log(query.where);
-
     const manifestations = await Manifestation.findAndCountAll(query);
+
+    // retorna qual a ultima página
+    manifestations.last_page = Math.ceil(manifestations.count / 10);
 
     return manifestations;
   }

--- a/src/app/services/SearchManifestationService.js
+++ b/src/app/services/SearchManifestationService.js
@@ -40,27 +40,7 @@ class SearchManifestationService {
     return [filteredTypes, filteredCategories];
   }
 
-  checkIfProtocol(text) {
-    if (text && !text.match(/\d*-\d/)) return false;
-
-    return true;
-  }
-
-  makeWhereQuery(text, types, categories, page, isRead, isProtocol) {
-    let textSearch;
-
-    if (text) {
-      if (isProtocol) {
-        // define busca por protocolo
-        textSearch = { protocol: text };
-      } else {
-        // define busca por título
-        textSearch = {
-          title: { [Op.like]: `%${text}%` },
-        };
-      }
-    }
-
+  makeWhereQuery(text, types, categories, page, isRead) {
     const query = {
       include: [
         {
@@ -91,7 +71,7 @@ class SearchManifestationService {
       where: {
         ...(!isRead && { read: 0 }),
         [Op.and]: [
-          textSearch,
+          text ? { title: { [Op.like]: `%${text}%` } } : undefined,
           types.length > 0
             ? {
                 type_id: {
@@ -111,7 +91,6 @@ class SearchManifestationService {
   async run(text, options, page = 1, isRead = true) {
     let types = [];
     let categories = [];
-    const isProtocol = this.checkIfProtocol(text);
 
     if (options) {
       [types, categories] = await this.fetchOptionsIds(options);
@@ -125,14 +104,12 @@ class SearchManifestationService {
       typesIds,
       categoriesIds,
       page,
-      isRead,
-      isProtocol
+      isRead
     );
 
-    const manifestations = await Manifestation.findAndCountAll(query);
+    console.log(query.where);
 
-    // retorna qual a ultima página
-    manifestations.last_page = Math.ceil(manifestations.count / 10);
+    const manifestations = await Manifestation.findAndCountAll(query);
 
     return manifestations;
   }

--- a/src/database/migrations/20191031005449-manifestation_status_history.js
+++ b/src/database/migrations/20191031005449-manifestation_status_history.js
@@ -18,10 +18,6 @@ module.exports = {
           autoIncrement: true,
           primaryKey: true,
         },
-        title: {
-          type: Sequelize.STRING,
-          allowNull: false,
-        },
         description: {
           type: Sequelize.TEXT,
           allowNull: false,
@@ -40,7 +36,13 @@ module.exports = {
           onDelete: 'CASCADE',
           allowNull: false,
         },
-        // TODO: REFERÊNCIA A SECRETARIA AQUI
+        secretary_id: {
+          type: Sequelize.INTEGER,
+          references: { model: 'secretariats', key: 'id' },
+          onUpdate: 'CASCADE',
+          onDelete: 'CASCADE',
+          allowNull: true,
+        },
         created_at: {
           type: Sequelize.DATE,
           allowNull: false,

--- a/src/routes.js
+++ b/src/routes.js
@@ -107,7 +107,7 @@ router.get('/user', UserController.fetch);
 router.get('/user/:id', UserController.show);
 
 router.get(
-  '/manifestation/:manifestationId/status',
+  '/manifestation/:idOrProtocol/status',
   ManifestationStatusHistoryController.fetch
 );
 router.get(

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,6 +1,7 @@
 /**
  * Arquivo responsável por expor todas as rotas para a classe App
  */
+
 import { Router } from 'express';
 
 // controllers
@@ -13,6 +14,7 @@ import StatusController from './app/controller/status.controller';
 import RoleController from './app/controller/role.controller';
 import SecretaryController from './app/controller/secretary.controller';
 import MailController from './app/controller/mail.controller';
+import ManifestationStatusHistoryController from './app/controller/manifestationStatusHistory.controller';
 
 // middleware para configurar os dados iniciais do banco
 import setupDbInitialData from './app/middlewares/setupDbInitialData';
@@ -29,6 +31,7 @@ import GenericValidator from './app/middlewares/validators/Generic';
 import RoleValidation from './app/middlewares/validators/Role';
 import SecretaryValidator from './app/middlewares/validators/Secretary';
 import MailValidator from './app/middlewares/validators/Mail';
+import ManifestationStatusHistoryValidor from './app/middlewares/validators/ManifestationStatusHistory';
 
 // a classe Router cria manipuladores de rotas modulares e montáveis
 const router = new Router();
@@ -103,9 +106,30 @@ router.get('/secretary/:id', SecretaryController.show);
 router.get('/user', UserController.fetch);
 router.get('/user/:id', UserController.show);
 
+router.get(
+  '/manifestation/:manifestationId/status',
+  ManifestationStatusHistoryController.fetch
+);
+router.get(
+  '/manifestation/status/:id',
+  ManifestationStatusHistoryController.show
+);
+router.post(
+  '/manifestation/:manifestationId/status',
+  ManifestationStatusHistoryValidor.save,
+  ManifestationStatusHistoryController.save
+);
+router.put(
+  '/manifestation/status/:id',
+  ManifestationStatusHistoryValidor.update,
+  ManifestationStatusHistoryController.update
+);
+
 router.post('/email', MailValidator, MailController.send);
 
-// A partir daqui serão rotas de Administradores Master
+/**
+ * Rotas de Admin Master
+ */
 router.use(RolesMiddleware.adminMaster);
 
 router.post('/category', GenericValidator.save, CategoryController.save);

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,10 +1,5 @@
 /**
  * Arquivo responsável por expor todas as rotas para a classe App
- *
- * Funciona assim:
- *  router.get('caminho da rota', funçãoQueVaiTratarARota)
- *
- * router.get(), router.post(), router.put(), router.delete()
  */
 import { Router } from 'express';
 
@@ -45,18 +40,7 @@ if (process.env.NODE_ENV === 'test') {
 }
 
 /**
- * Rotas de Teste
- */
-router.get('/user/:id?', UserController.fetch);
-
-/**
  *  Rotas publicas
- */
-
-/*
- * TODO: para criar um User definindo uma Role é necessário saber a Role, mas ela só é passada
- * após a execução do middleware de autenticação, talvez seja necessário criar uma rota
- * somente para criação de usuários admin
  */
 
 router.post('/user', UserValidator.save, UserController.save);
@@ -75,33 +59,51 @@ router.use(AuthMiddleware);
  * Rotas privadas
  * necessário um Token
  */
+
 router.post(
   '/manifestation',
   ManifestationValidator.save,
   ManifestationController.save
 );
+
 router.put(
   '/manifestation/:id',
   ManifestationValidator.update,
   ManifestationController.update
 );
 router.put('/user/:id', UserValidator.update, UserController.update);
-router.get('/category/:id?', CategoryController.fetch);
-router.get('/type/:id?', TypeController.fetch);
+
+router.get('/category', CategoryController.fetch);
+router.get('/category/:id', CategoryController.show);
+
+router.get('/type', TypeController.fetch);
+router.get('/type/:id', TypeController.show);
+
 router.get(
-  '/manifestation/:id?',
+  '/manifestation',
   ManifestationValidator.fetch,
   ManifestationController.fetch
 );
+router.get('/manifestation/:idOrProtocol', ManifestationController.show);
 
-// A partir daqui serão rotas de Administradores
+/**
+ * Rotas de Administrador
+ */
 router.use(RolesMiddleware.admin);
 
-router.get('/role/:id?', RoleController.fetch);
-router.get('/status/:id?', StatusController.fetch);
-router.get('/secretary/:id?', SecretaryController.fetch);
+router.get('/role', RoleController.fetch);
+router.get('/role/:id', RoleController.show);
 
-router.post('/email', MailValidator, MailController.save);
+router.get('/status', StatusController.fetch);
+router.get('/status/:id', StatusController.show);
+
+router.get('/secretary', SecretaryController.fetch);
+router.get('/secretary/:id', SecretaryController.show);
+
+router.get('/user', UserController.fetch);
+router.get('/user/:id', UserController.show);
+
+router.post('/email', MailValidator, MailController.send);
 
 // A partir daqui serão rotas de Administradores Master
 router.use(RolesMiddleware.adminMaster);


### PR DESCRIPTION
Simplificando todos os FETCH.
`fetch` agora só retorna vários itens, enquanto `show` retorna apenas um item específico.
Criei ManifestationStatusHistory, para manter os registros de status de uma manifestação. Totalmente documentado no `routes.md`.

Diminui um pouco o protocolo e concertei um negócio em relação ao dia.

Porém o protocolo está dentro de um hook `afterCreate`, o que significa que o protocolo não existe quando você criar. Exemplo: não terá feito o protocolo quando você receber o retorno da criação de manifestação. O protocolo ficara 0, por que foi esse o default que eu defini.

Motivos para eu não ter usado um hook melhor, o `beforeSave`: esse hook acontece antes de ter sido registrado no banco, ou seja, não tem acesso ao id. Então como eu não consegui formular um protocolo bom sem id eu resolvi fazer desse jeito.

Me certifiquei de fazer os tests passarem.